### PR TITLE
Update `TWC 2026` for the Round of 16 stage

### DIFF
--- a/wiki/Tournaments/TWC/2026/en.md
+++ b/wiki/Tournaments/TWC/2026/en.md
@@ -60,6 +60,7 @@ The osu!taiko World Cup 2026 is run by the [osu! team](/wiki/People/osu!_team) a
 - [Livestream](https://www.twitch.tv/osulive)
 - [Discussion thread](https://osu.ppy.sh/community/forums/topics/2179201)
 - [Tournament listing](https://osu.ppy.sh/community/tournaments/54)
+- [Challonge bracket](https://challonge.com/TWC2026)
 - [Pick'ems page](https://pickem.hwc.hr/tournaments/192) hosted by ::{ flag=DE }:: [hallowatcher](https://osu.ppy.sh/users/1874761)
 - [Support your country with a profile banner](https://osu.ppy.sh/store/products/1664)
 

--- a/wiki/Tournaments/TWC/2026/en.md
+++ b/wiki/Tournaments/TWC/2026/en.md
@@ -44,12 +44,14 @@ The osu!taiko World Cup 2026 is run by the [osu! team](/wiki/People/osu!_team) a
 | Managers | ::{ flag=CA }:: [Azer](https://osu.ppy.sh/users/2155578), ::{ flag=US }:: [ChillierPear](https://osu.ppy.sh/users/9501251), ::{ flag=BR }:: [LeoFLT](https://osu.ppy.sh/users/3668779), ::{ flag=CN }:: [Sakura006](https://osu.ppy.sh/users/10365024) |
 | Mappool selectors | ::{ flag=SE }:: **[Nurend](https://osu.ppy.sh/users/9905079)**, ::{ flag=JP }:: [4sbet1](https://osu.ppy.sh/users/11563671), ::{ flag=JP }:: [miyagishima](https://osu.ppy.sh/users/8027517), ::{ flag=DE }:: [Nwolf](https://osu.ppy.sh/users/1910766), ::{ flag=DE }:: [Xay](https://osu.ppy.sh/users/961417) |
 | Mappool playtesters | ::{ flag=US }:: [Backfire](https://osu.ppy.sh/users/263110), ::{ flag=FR }:: [Briesmas](https://osu.ppy.sh/users/2865172), ::{ flag=JP }:: [Grape\_Tea](https://osu.ppy.sh/users/9540073), ::{ flag=ID }:: [Katdon\_donKat](https://osu.ppy.sh/users/8089664), ::{ flag=JP }:: [Maimaing](https://osu.ppy.sh/users/14520910), ::{ flag=JP }:: [My Angel Eru](https://osu.ppy.sh/users/26454214), ::{ flag=SE }:: [Nurend](https://osu.ppy.sh/users/9905079), ::{ flag=NO }:: [roufou](https://osu.ppy.sh/users/1109122), ::{ flag=JP }:: [shinjinhome](https://osu.ppy.sh/users/30147970), ::{ flag=US }:: [Shyguy](https://osu.ppy.sh/users/178038), ::{ flag=TW }:: [X a v y](https://osu.ppy.sh/users/3738344) |
-| Mappers | ::{ flag=SG }:: [\_gt](https://osu.ppy.sh/users/8301957), ::{ flag=JP }:: [4sbet1](https://osu.ppy.sh/users/11563671), ::{ flag=HK }:: [aabc271](https://osu.ppy.sh/users/155707), ::{ flag=JP }:: [Eriha](https://osu.ppy.sh/users/16320311), ::{ flag=JP }:: [hz404](https://osu.ppy.sh/users/14947043), ::{ flag=NL }:: [ikin5050](https://osu.ppy.sh/users/4007649), ::{ flag=JP }:: [layxa](https://osu.ppy.sh/users/14800030), ::{ flag=JP }:: [miyagishima](https://osu.ppy.sh/users/8027517), ::{ flag=JP }:: [My Angel Eru](https://osu.ppy.sh/users/26454214), ::{ flag=DE }:: [Nwolf](https://osu.ppy.sh/users/1910766), ::{ flag=NO }:: [roufou](https://osu.ppy.sh/users/1109122), ::{ flag=JP }:: [tasuke912](https://osu.ppy.sh/users/2774767), ::{ flag=DE }:: [Xay](https://osu.ppy.sh/users/961417), *more TBA* |
+| Mappers | ::{ flag=SG }:: [\_gt](https://osu.ppy.sh/users/8301957), ::{ flag=JP }:: [4sbet1](https://osu.ppy.sh/users/11563671), ::{ flag=HK }:: [aabc271](https://osu.ppy.sh/users/155707), ::{ flag=JP }:: [Eriha](https://osu.ppy.sh/users/16320311), ::{ flag=PH }:: [Eyenine](https://osu.ppy.sh/users/1259391), ::{ flag=JP }:: [Grape\_Tea](https://osu.ppy.sh/users/9540073), ::{ flag=TN }:: [Hivie](https://osu.ppy.sh/users/14102976), ::{ flag=JP }:: [hz404](https://osu.ppy.sh/users/14947043), ::{ flag=NL }:: [ikin5050](https://osu.ppy.sh/users/4007649), ::{ flag=JP }:: [layxa](https://osu.ppy.sh/users/14800030), ::{ flag=JP }:: [Maimaing](https://osu.ppy.sh/users/14520910), ::{ flag=GB }:: [Meguminx\_MAS](https://osu.ppy.sh/users/17797595), ::{ flag=JP }:: [miyagishima](https://osu.ppy.sh/users/8027517), ::{ flag=JP }:: [My Angel Eru](https://osu.ppy.sh/users/26454214), ::{ flag=RU }:: [Nozdormu](https://osu.ppy.sh/users/7169208), ::{ flag=SE }:: [Nurend](https://osu.ppy.sh/users/9905079), ::{ flag=DE }:: [Nwolf](https://osu.ppy.sh/users/1910766), ::{ flag=DE }:: [OnosakiHito](https://osu.ppy.sh/users/290128), ::{ flag=NO }:: [roufou](https://osu.ppy.sh/users/1109122), ::{ flag=JP }:: [tasuke912](https://osu.ppy.sh/users/2774767), ::{ flag=DE }:: [Xay](https://osu.ppy.sh/users/961417), *more TBA* |
 | Commentators | **::{ flag=US }:: [ChillierPear](https://osu.ppy.sh/users/9501251)**, ::{ flag=SG }:: [_gt](https://osu.ppy.sh/users/8301957), ::{ flag=AU }:: [Beat43210](https://osu.ppy.sh/users/5664171), ::{ flag=US }:: [Bronzecrank](https://osu.ppy.sh/users/14173115), ::{ flag=US }:: [driodx](https://osu.ppy.sh/users/9709548), ::{ flag=GB }:: [Ethan_Taikotris](https://osu.ppy.sh/users/16968817), ::{ flag=US }:: [ETHN](https://osu.ppy.sh/users/9536977), ::{ flag=CA }:: [janitore](https://osu.ppy.sh/users/3307897), ::{ flag=AU }:: [Jaye](https://osu.ppy.sh/users/4841352), ::{ flag=DE }:: [Joogs](https://osu.ppy.sh/users/8844167), ::{ flag=DE }:: [Nwolf](https://osu.ppy.sh/users/1910766), ::{ flag=GB }:: [overdahedge2015](https://osu.ppy.sh/users/9864847), ::{ flag=GB }:: [Teezel](https://osu.ppy.sh/users/7528639), ::{ flag=AT }:: [Yasuho](https://osu.ppy.sh/users/8458835), ::{ flag=HK }:: [YonGin](https://osu.ppy.sh/users/7109317) |
+| Commentators (special guests) | ::{ flag=HK }:: [Anchor](https://osu.ppy.sh/users/418756), ::{ flag=ID }:: [BlankTap](https://osu.ppy.sh/users/10137131), ::{ flag=GB }:: [Bubbleman](https://osu.ppy.sh/users/5182050), ::{ flag=CA }:: [D I O](https://osu.ppy.sh/users/3958619), ::{ flag=US }:: [Dohland](https://osu.ppy.sh/users/5220511), ::{ flag=GB }:: [Doomsday](https://osu.ppy.sh/users/18983), ::{ flag=US }:: [Dynascape](https://osu.ppy.sh/users/8784587), ::{ flag=GB }:: [epic man 2](https://osu.ppy.sh/users/14566000), ::{ flag=TN }:: [Hivie](https://osu.ppy.sh/users/14102976), ::{ flag=US }:: [hubbawubba](https://osu.ppy.sh/users/15910288), ::{ flag=CA }:: [I\-Flame](https://osu.ppy.sh/users/11257542), ::{ flag=NL }:: [ikin5050](https://osu.ppy.sh/users/4007649), ::{ flag=KZ }:: [Lightin](https://osu.ppy.sh/users/7595619), ::{ flag=PH }:: [LivelyPeninsula](https://osu.ppy.sh/users/11517895), ::{ flag=GB }:: [Nathanial](https://osu.ppy.sh/users/9169747), ::{ flag=NZ }:: [Old Zealand](https://osu.ppy.sh/users/5750235), ::{ flag=US }:: [Snowleopard](https://osu.ppy.sh/users/3790227), ::{ flag=US }:: [Sparky](https://osu.ppy.sh/users/3187959), ::{ flag=US }:: [SunApple](https://osu.ppy.sh/users/11817622), ::{ flag=PH }:: [SurfChu85](https://osu.ppy.sh/users/4469895), ::{ flag=NL }:: [TaikoMom](https://osu.ppy.sh/users/9086438), ::{ flag=US }:: [this1neguy](https://osu.ppy.sh/users/1797189) |
 | Referees | **::{ flag=BR }:: [LeoFLT](https://osu.ppy.sh/users/3668779)**, ::{ flag=IN }:: [\-Space](https://osu.ppy.sh/users/7720204), ::{ flag=US }:: [akace100](https://osu.ppy.sh/users/9308128), ::{ flag=NL }:: [Albionthegreat](https://osu.ppy.sh/users/9853595), ::{ flag=BR }:: [DizzyH](https://osu.ppy.sh/users/9896172), ::{ flag=SE }:: [ellen\-](https://osu.ppy.sh/users/7630166), ::{ flag=VN }:: [Hoaq](https://osu.ppy.sh/users/7696512), ::{ flag=CL }:: [Isita](https://osu.ppy.sh/users/13973026), ::{ flag=AR }:: [KlBBY](https://osu.ppy.sh/users/12182138), ::{ flag=NL }:: [nik](https://osu.ppy.sh/users/10077264), ::{ flag=FI }:: [shdewz](https://osu.ppy.sh/users/10000899), ::{ flag=US }:: [Suicune3](https://osu.ppy.sh/users/6895187), ::{ flag=US }:: [tigereyes144](https://osu.ppy.sh/users/6499811), ::{ flag=GB }:: [Yazzehh](https://osu.ppy.sh/users/7068973) |
 | Statisticians | **::{ flag=FI }:: [shdewz](https://osu.ppy.sh/users/10000899)**, ::{ flag=BR }:: [LeoFLT](https://osu.ppy.sh/users/3668779) |
 | osu! original design | **::{ flag=CN }:: [Sakura006](https://osu.ppy.sh/users/10365024)**, *more TBA* |
 | Tournament design | ::{ flag=CN }:: [AlexDunk](https://osu.ppy.sh/users/9194799), ::{ flag=US }:: [ChillierPear](https://osu.ppy.sh/users/9501251), ::{ flag=HK }:: [Detristy](https://osu.ppy.sh/users/38325708), ::{ flag=RU }:: [LeeNarie](https://osu.ppy.sh/users/2667849), ::{ flag=ID }:: [LenLitchu](https://osu.ppy.sh/users/34098325), ::{ flag=CN }:: [Sakura006](https://osu.ppy.sh/users/10365024) |
+| Musician | [OLDUCT](https://lit.link/olduct) |
 
 ## Links
 
@@ -59,6 +61,7 @@ The osu!taiko World Cup 2026 is run by the [osu! team](/wiki/People/osu!_team) a
 - [Discussion thread](https://osu.ppy.sh/community/forums/topics/2179201)
 - [Tournament listing](https://osu.ppy.sh/community/tournaments/54)
 - [Pick'ems page](https://pickem.hwc.hr/tournaments/192) hosted by ::{ flag=DE }:: [hallowatcher](https://osu.ppy.sh/users/1874761)
+- [Support your country with a profile banner](https://osu.ppy.sh/store/products/1664)
 
 ## Participants
 
@@ -114,44 +117,72 @@ Captains are listed in **bold**.
 
 The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/6b38d4e22d9926c8e0bb24c5a634ac8d).
 
-## Match schedule: Group stage
+## Match schedule: Round of 16
 
-### Saturday, 21 March 2026
-
-| ID | Team A | Team B | Match time | Twitch stream |
-| :-: | --: | :-- | :-- | :-: |
-| G1 | New Zealand ::{ flag=NZ }:: | ::{ flag=SE }:: Sweden | [Mar 21 (Sat) 10:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260321T100000&p1=1440&p2=264&p3=239) | [osulive](https://twitch.tv/osulive) |
-| A3 | Hong Kong ::{ flag=HK }:: | ::{ flag=VN }:: Vietnam | [Mar 21 (Sat) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260321T130000&p1=1440&p2=102&p3=95) | [osulive](https://twitch.tv/osulive) |
-| B1 | Malaysia ::{ flag=MY }:: | ::{ flag=ID }:: Indonesia | [Mar 21 (Sat) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260321T130000&p1=1440&p2=122&p3=108) | [osulive_2](https://twitch.tv/osulive_2) |
-| B2 | Malaysia ::{ flag=MY }:: | ::{ flag=PH }:: Philippines | [Mar 21 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260321T140000&p1=1440&p2=122&p3=145) | [osulive_2](https://twitch.tv/osulive_2) |
-| C2 | Russian Federation ::{ flag=RU }:: | ::{ flag=PL }:: Poland | [Mar 21 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260321T140000&p1=1440&p2=166&p3=262) | [osulive](https://twitch.tv/osulive) |
-| A1 | Norway ::{ flag=NO }:: | ::{ flag=HK }:: Hong Kong | [Mar 21 (Sat) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260321T160000&p1=1440&p2=187&p3=102) | [osulive](https://twitch.tv/osulive) |
-| C1 | Russian Federation ::{ flag=RU }:: | ::{ flag=PT }:: Portugal | [Mar 21 (Sat) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260321T160000&p1=1440&p2=166&p3=133) | [osulive_2](https://twitch.tv/osulive_2) |
-| D2 | Slovakia ::{ flag=SK }:: | ::{ flag=MX }:: Mexico | [Mar 21 (Sat) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260321T170000&p1=1440&p3=155) | [osulive](https://twitch.tv/osulive) |
-| F1 | Germany ::{ flag=DE }:: | ::{ flag=FI }:: Finland | [Mar 21 (Sat) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260321T170000&p1=1440&p2=37&p3=101) | [osulive_2](https://twitch.tv/osulive_2) |
-| E3 | Canada ::{ flag=CA }:: | ::{ flag=AR }:: Argentina | [Mar 21 (Sat) 18:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260321T180000&p1=1440&p2=188&p3=51) | [osulive](https://twitch.tv/osulive) |
-| D3 | France ::{ flag=FR }:: | ::{ flag=MX }:: Mexico | [Mar 21 (Sat) 19:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260321T190000&p1=1440&p2=195&p3=155) | [osulive](https://twitch.tv/osulive) |
-| E1 | United Kingdom ::{ flag=GB }:: | ::{ flag=CA }:: Canada | [Mar 21 (Sat) 20:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260321T200000&p1=1440&p2=136&p3=188) | [osulive](https://twitch.tv/osulive) |
-| G3 | Sweden ::{ flag=SE }:: | ::{ flag=PE }:: Peru | [Mar 21 (Sat) 20:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260321T200000&p1=1440&p2=239&p3=131) | [osulive_2](https://twitch.tv/osulive_2) |
-| H1 | Australia ::{ flag=AU }:: | ::{ flag=NL }:: Netherlands | [Mar 21 (Sat) 23:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260321T230000&p1=1440&p2=57&p3=16) | [osulive](https://twitch.tv/osulive) |
-
-### Sunday, 22 March 2026
+### Saturday, 28 March 2026
 
 | ID | Team A | Team B | Match time | Twitch stream |
 | :-: | --: | :-- | :-- | :-: |
-| H2 | Australia ::{ flag=AU }:: | ::{ flag=CO }:: Colombia | [Mar 22 (Sun) 01:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260322T010000&p1=1440&p2=57&p3=41) | [osulive](https://twitch.tv/osulive) |
-| G2 | New Zealand ::{ flag=NZ }:: | ::{ flag=PE }:: Peru | [Mar 22 (Sun) 02:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260322T020000&p1=1440&p2=264&p3=131) | [osulive](https://twitch.tv/osulive) |
-| F3 | Finland ::{ flag=FI }:: | ::{ flag=CH }:: Switzerland | [Mar 22 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260322T130000&p1=1440&p2=101&p3=270) | [osulive](https://twitch.tv/osulive) |
-| A2 | Norway ::{ flag=NO }:: | ::{ flag=VN }:: Vietnam | [Mar 22 (Sun) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260322T150000&p1=1440&p2=187&p3=95) | [osulive](https://twitch.tv/osulive) |
-| B3 | Indonesia ::{ flag=ID }:: | ::{ flag=PH }:: Philippines | [Mar 22 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260322T160000&p1=1440&p2=108&p3=145) | [osulive](https://twitch.tv/osulive) |
-| C3 | Portugal ::{ flag=PT }:: | ::{ flag=PL }:: Poland | [Mar 22 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260322T160000&p1=1440&p2=133&p3=262) | [osulive_2](https://twitch.tv/osulive_2) |
-| D1 | Slovakia ::{ flag=SK }:: | ::{ flag=FR }:: France | [Mar 22 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260322T160000&p1=1440&p3=195) | [osufrlive](https://twitch.tv/osufrlive) |
-| E2 | United Kingdom ::{ flag=GB }:: | ::{ flag=AR }:: Argentina | [Mar 22 (Sun) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260322T170000&p1=1440&p2=136&p3=51) | [osulive](https://twitch.tv/osulive) |
-| H3 | Netherlands ::{ flag=NL }:: | ::{ flag=CO }:: Colombia | [Mar 22 (Sun) 18:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260322T180000&p1=1440&p2=16&p3=41) | [osulive](https://twitch.tv/osulive) |
-| F2 | Germany ::{ flag=DE }:: | ::{ flag=CH }:: Switzerland | [Mar 22 (Sun) 19:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260322T190000&p1=1440&p2=37&p3=270) | [osulive](https://twitch.tv/osulive) |
-|  | Round of 16 | mappool showcase | [Mar 22 (Sun) 20:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260322T200000&p1=1440) | [osulive](https://twitch.tv/osulive) |
+| 1 | Japan ::{ flag=JP }:: | ::{ flag=AU }:: Australia | [Mar 28 (Sat) 08:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260328T080000&p1=1440&p2=248&p3=57) | [osulive](https://twitch.tv/osulive) |
+| 6 | China ::{ flag=CN }:: | ::{ flag=ID }:: Indonesia | [Mar 28 (Sat) 09:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260328T090000&p1=1440&p2=33&p3=108) | [osulive](https://twitch.tv/osulive) |
+| 2 | Taiwan ::{ flag=TW }:: | ::{ flag=NO }:: Norway | [Mar 28 (Sat) 10:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260328T100000&p1=1440&p2=241&p3=187) | [osulive](https://twitch.tv/osulive) |
+| 4 | South Korea ::{ flag=KR }:: | ::{ flag=FR }:: France | [Mar 28 (Sat) 11:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260328T110000&p1=1440&p2=235&p3=195) | [osulive](https://twitch.tv/osulive) |
+| 9 | Colombia ::{ flag=CO }:: | ::{ flag=VN }:: Vietnam | [Mar 28 (Sat) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260328T160000&p1=1440&p2=41&p3=95) | [osulive](https://twitch.tv/osulive) |
+| 7 | Brazil ::{ flag=BR }:: | ::{ flag=FI }:: Finland | [Mar 28 (Sat) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260328T170000&p1=1440&p2=45&p3=101) | [osulive](https://twitch.tv/osulive) |
+| 3 | United States ::{ flag=US }:: | ::{ flag=GB }:: United Kingdom | [Mar 28 (Sat) 18:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260328T180000&p1=1440&p2=263&p3=136) | [osulive](https://twitch.tv/osulive) |
+
+### Sunday, 29 March 2026
+
+| ID | Team A | Team B | Match time | Twitch stream |
+| :-: | --: | :-- | :-- | :-: |
+| 5 | Chile ::{ flag=CL }:: | ::{ flag=NZ }:: New Zealand | [Mar 29 (Sun) 02:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260329T020000&p1=1440&p2=232&p3=264) | [osulive](https://twitch.tv/osulive) |
+| 13 | Peru ::{ flag=PE }:: | ::{ flag=MY }:: Malaysia | [Mar 29 (Sun) 03:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260329T030000&p1=1440&p2=131&p3=122) | [osulive](https://twitch.tv/osulive) |
+| 14 | Philippines ::{ flag=PH }:: | ::{ flag=SE }:: Sweden | [Mar 29 (Sun) 10:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260329T100000&p1=1440&p2=145&p3=239) | [osulive](https://twitch.tv/osulive) |
+| 10 | Hong Kong ::{ flag=HK }:: | ::{ flag=NL }:: Netherlands | [Mar 29 (Sun) 11:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260329T110000&p1=1440&p2=102&p3=16) | [osulive](https://twitch.tv/osulive) |
+| 16 | Poland ::{ flag=PL }:: | ::{ flag=DE }:: Germany | [Mar 29 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260329T120000&p1=1440&p2=262&p3=37) | [osulive](https://twitch.tv/osulive) |
+| 15 | Switzerland ::{ flag=CH }:: | ::{ flag=PT }:: Portugal | [Mar 29 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260329T130000&p1=1440&p2=270&p3=133) | [osulive](https://twitch.tv/osulive) |
+| 11 | Argentina ::{ flag=AR }:: | ::{ flag=SK }:: Slovakia | [Mar 29 (Sun) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260329T150000&p1=1440&p2=51) | [osulive](https://twitch.tv/osulive) |
+| 8 | Italy ::{ flag=IT }:: | ::{ flag=RU }:: Russian Federation | [Mar 29 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260329T160000&p1=1440&p2=215&p3=166) | [osulive](https://twitch.tv/osulive) |
+| 12 | Mexico ::{ flag=MX }:: | ::{ flag=CA }:: Canada | [Mar 29 (Sun) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20260329T170000&p1=1440&p2=155&p3=188) | [osulive](https://twitch.tv/osulive) |
+|  | Quarterfinals | mappool showcase | [Mar 29 (Sun) 18:00 UTC (estimated)](https://www.timeanddate.com/worldclock/converter.html?iso=20260329T180000&p1=1440) | [osulive](https://twitch.tv/osulive) |
 
 ## Match results
+
+### Group stage
+
+Saturday, 21 March 2026:
+
+| ID | Team A |  |  | Team B | Match link | VOD link |
+| :-: | --: | :-: | :-: | :-- | :-- | :-- |
+| G1 | **New Zealand** ::{ flag=NZ }:: | **5** | 1 | ::{ flag=SE }:: Sweden | [#1](https://osu.ppy.sh/community/matches/120767392) | [#1](https://www.twitch.tv/videos/2727997776) |
+| A3 | Hong Kong ::{ flag=HK }:: | 4 | **5** | ::{ flag=VN }:: **Vietnam** | [#1](https://osu.ppy.sh/community/matches/120768257) | [#1](https://www.twitch.tv/videos/2728054593) |
+| B1 | Malaysia ::{ flag=MY }:: | 2 | **5** | ::{ flag=ID }:: **Indonesia** | [#1](https://osu.ppy.sh/community/matches/120768357) | [#1](https://www.twitch.tv/videos/2728058074) |
+| B2 | **Malaysia** ::{ flag=MY }:: | **5** | 3 | ::{ flag=PH }:: Philippines | [#1](https://osu.ppy.sh/community/matches/120768725) | [#1](https://www.twitch.tv/videos/2728082264) |
+| C2 | **Russian Federation** ::{ flag=RU }:: | **5** | 1 | ::{ flag=PL }:: Poland | [#1](https://osu.ppy.sh/community/matches/120768711) | [#1](https://www.twitch.tv/videos/2728071951) |
+| A1 | **Norway** ::{ flag=NO }:: | **5** | 2 | ::{ flag=HK }:: Hong Kong | [#1](https://osu.ppy.sh/community/matches/120769577) | [#1](https://www.twitch.tv/videos/2728162675) |
+| C1 | **Russian Federation** ::{ flag=RU }:: | **5** | 2 | ::{ flag=PT }:: Portugal | [#1](https://osu.ppy.sh/community/matches/120769646) | [#1](https://www.twitch.tv/videos/2728159990) |
+| D2 | **Slovakia** ::{ flag=SK }:: | **5** | 1 | ::{ flag=MX }:: Mexico | [#1](https://osu.ppy.sh/community/matches/120769943) | [#1](https://www.twitch.tv/videos/2728205069) |
+| F1 | Germany ::{ flag=DE }:: | 3 | **5** | ::{ flag=FI }:: **Finland** | [#1](https://osu.ppy.sh/community/matches/120769993) | [#1](https://www.twitch.tv/videos/2728214962) |
+| E3 | **Canada** ::{ flag=CA }:: | **5** | 1 | ::{ flag=AR }:: Argentina | [#1](https://osu.ppy.sh/community/matches/120770395) | [#1](https://www.twitch.tv/videos/2728247019) |
+| D3 | **France** ::{ flag=FR }:: | **5** | 3 | ::{ flag=MX }:: Mexico | [#1](https://osu.ppy.sh/community/matches/120770888) | [#1](https://www.twitch.tv/videos/2728325209) |
+| E1 | **United Kingdom** ::{ flag=GB }:: | **5** | 2 | ::{ flag=CA }:: Canada | [#1](https://osu.ppy.sh/community/matches/120771388) | [#1](https://www.twitch.tv/videos/2728356936) |
+| G3 | **Sweden** ::{ flag=SE }:: | **5** | 1 | ::{ flag=PE }:: Peru | [#1](https://osu.ppy.sh/community/matches/120771369) | [#1](https://www.twitch.tv/videos/2728347237) |
+| H1 | **Australia** ::{ flag=AU }:: | **5** | 4 | ::{ flag=NL }:: Netherlands | [#1](https://osu.ppy.sh/community/matches/120772730) | [#1](https://www.twitch.tv/videos/2728498363) |
+
+Sunday, 22 March 2026:
+
+| ID | Team A |  |  | Team B | Match link | VOD link |
+| :-: | --: | :-: | :-: | :-- | :-- | :-- |
+| H2 | **Australia** ::{ flag=AU }:: | **5** | 0 | ::{ flag=CO }:: Colombia | [#1](https://osu.ppy.sh/community/matches/120773383) | [#1](https://www.twitch.tv/videos/2728570883) |
+| G2 | **New Zealand** ::{ flag=NZ }:: | **5** | 1 | ::{ flag=PE }:: Peru | [#1](https://osu.ppy.sh/community/matches/120773667) | [#1](https://www.twitch.tv/videos/2728616062) |
+| F3 | **Finland** ::{ flag=FI }:: | **5** | 0 | ::{ flag=CH }:: Switzerland | [#1](https://osu.ppy.sh/community/matches/120776444) | [#1](https://www.twitch.tv/videos/2728920451) |
+| A2 | **Norway** ::{ flag=NO }:: | **5** | 1 | ::{ flag=VN }:: Vietnam | [#1](https://osu.ppy.sh/community/matches/120777292) | [#1](https://www.twitch.tv/videos/2729002523) |
+| B3 | **Indonesia** ::{ flag=ID }:: | **5** | 4 | ::{ flag=PH }:: Philippines | [#1](https://osu.ppy.sh/community/matches/120777694) | [#1](https://www.twitch.tv/videos/2729072460) |
+| C3 | **Portugal** ::{ flag=PT }:: | **5** | 1 | ::{ flag=PL }:: Poland | [#1](https://osu.ppy.sh/community/matches/120777778) | [#1](https://www.twitch.tv/videos/2729045431) |
+| D1 | Slovakia ::{ flag=SK }:: | 3 | **5** | ::{ flag=FR }:: **France** | [#1](https://osu.ppy.sh/community/matches/120777733) |  |
+| E2 | **United Kingdom** ::{ flag=GB }:: | **5** | 0 | ::{ flag=AR }:: Argentina | [#1](https://osu.ppy.sh/community/matches/120778155) | [#1](https://www.twitch.tv/videos/2729088884) |
+| H3 | **Netherlands** ::{ flag=NL }:: | **5** | 0 | ::{ flag=CO }:: Colombia | [#1](https://osu.ppy.sh/community/matches/120778657) | [#1](https://www.twitch.tv/videos/2729136097) |
+| F2 | **Germany** ::{ flag=DE }:: | **5** | 3 | ::{ flag=CH }:: Switzerland | [#1](https://osu.ppy.sh/community/matches/120779049) | [#1](https://www.twitch.tv/videos/2729205905) |
 
 ### Qualifiers
 
@@ -204,7 +235,100 @@ View the Qualifier seed reveal VOD [here](https://www.twitch.tv/videos/272345629
 | #42 | ::{ flag=GT }:: Guatemala | 284 | 1,452,194 | [#1](https://osu.ppy.sh/community/matches/120717809) |
 | #43 | ::{ flag=BY }:: Belarus | 300 | 964,004 | [#1](https://osu.ppy.sh/community/matches/120730777) |
 
+## Groups
+
+Watch the Group drawings VOD [here](https://www.twitch.tv/videos/2723456293?t=1h11m5s).
+
+Group A:
+
+| # | Team | Wins | Losses | PF | PA | PD | Seed |
+| :-: | :-- | :-: | :-: | :-: | :-: | :-: | :-: |
+| #1 | ::{ flag=NO }:: Norway | **2** | 0 | 10 | 3 | **+7** | 14 |
+| #2 | ::{ flag=VN }:: Vietnam | **1** | 1 | 6 | 9 | **-3** | 26 |
+| #3 | ::{ flag=HK }:: Hong Kong | **0** | 2 | 6 | 10 | **-4** | 20 |
+
+Group B:
+
+| # | Team | Wins | Losses | PF | PA | PD | Seed |
+| :-: | :-- | :-: | :-: | :-: | :-: | :-: | :-: |
+| #1 | ::{ flag=ID }:: Indonesia | **2** | 0 | 10 | 6 | **+4** | 24 |
+| #2 | ::{ flag=MY }:: Malaysia | **1** | 1 | 7 | 8 | **-1** | 9 |
+| #3 | ::{ flag=PH }:: Philippines | **0** | 2 | 7 | 10 | **-3** | 25 |
+
+Group C:
+
+| # | Team | Wins | Losses | PF | PA | PD | Seed |
+| :-: | :-- | :-: | :-: | :-: | :-: | :-: | :-: |
+| #1 | ::{ flag=RU }:: Russian Federation | **2** | 0 | 10 | 3 | **+7** | 13 |
+| #2 | ::{ flag=PT }:: Portugal | **1** | 1 | 7 | 6 | **+1** | 19 |
+| #3 | ::{ flag=PL }:: Poland | **0** | 2 | 2 | 10 | **-8** | 29 |
+
+Group D:
+
+| # | Team | Wins | Losses | PF | PA | PD | Seed |
+| :-: | :-- | :-: | :-: | :-: | :-: | :-: | :-: |
+| #1 | ::{ flag=FR }:: France | **2** | 0 | 10 | 6 | **+4** | 21 |
+| #2 | ::{ flag=SK }:: Slovakia | **1** | 1 | 8 | 6 | **+2** | 15 |
+| #3 | ::{ flag=MX }:: Mexico | **0** | 2 | 4 | 10 | **-6** | 28 |
+
+Group E:
+
+| # | Team | Wins | Losses | PF | PA | PD | Seed |
+| :-: | :-- | :-: | :-: | :-: | :-: | :-: | :-: |
+| #1 | ::{ flag=GB }:: United Kingdom | **2** | 0 | 10 | 2 | **+8** | 10 |
+| #2 | ::{ flag=CA }:: Canada | **1** | 1 | 7 | 6 | **+1** | 18 |
+| #3 | ::{ flag=AR }:: Argentina | **0** | 2 | 1 | 10 | **-9** | 32 |
+
+Group F:
+
+| # | Team | Wins | Losses | PF | PA | PD | Seed |
+| :-: | :-- | :-: | :-: | :-: | :-: | :-: | :-: |
+| #1 | ::{ flag=FI }:: Finland | **2** | 0 | 10 | 3 | **+7** | 17 |
+| #2 | ::{ flag=DE }:: Germany | **1** | 1 | 8 | 8 | **0** | 12 |
+| #3 | ::{ flag=CH }:: Switzerland | **0** | 2 | 3 | 10 | **-7** | 31 |
+
+Group G:
+
+| # | Team | Wins | Losses | PF | PA | PD | Seed |
+| :-: | :-- | :-: | :-: | :-: | :-: | :-: | :-: |
+| #1 | ::{ flag=NZ }:: New Zealand | **2** | 0 | 10 | 2 | **+8** | 16 |
+| #2 | ::{ flag=SE }:: Sweden | **1** | 1 | 6 | 6 | **0** | 22 |
+| #3 | ::{ flag=PE }:: Peru | **0** | 2 | 2 | 10 | **-8** | 27 |
+
+Group H:
+
+| # | Team | Wins | Losses | PF | PA | PD | Seed |
+| :-: | :-- | :-: | :-: | :-: | :-: | :-: | :-: |
+| #1 | ::{ flag=AU }:: Australia | **2** | 0 | 10 | 4 | **+6** | 11 |
+| #2 | ::{ flag=NL }:: Netherlands | **1** | 1 | 9 | 5 | **+4** | 23 |
+| #3 | ::{ flag=CO }:: Colombia | **0** | 2 | 0 | 10 | **-10** | 30 |
+
 ## Mappools
+
+### Round of 16
+
+[View the showcase VOD here](https://www.twitch.tv/videos/2729260283)
+
+- No Mod
+  1. [sasakure.UK feat. Shirakami Fubuki - KINGWORLD (Faputa) \[KING ONI\]](https://osu.ppy.sh/beatmapsets/1784288#taiko/3654236)
+  2. [OLDUCT - Buy Now! (miyagishima) \[Inner Oni\]](https://osu.ppy.sh/beatmapsets/2527043#taiko/5582858)
+  3. [XH - Corrupted Paywall (Meguminx\_MAS) \[Hell Oni\]](https://osu.ppy.sh/beatmapsets/2527046#taiko/5582863)
+  4. [Xyris - Vitality Charger (feat. Hanakuma Chifuyu) (Nozdormu) \[You Charge My Vitality! \>w\<\]](https://osu.ppy.sh/beatmapsets/2527052#taiko/5582874)
+  5. [Xavlegbmaofffassssitimiwoamndutroabcwapwaeiippohfffx - Pneumonoultramicroscopicsilicovolcanoconiosis (Xay) \[Eellogofusciouhipoppokunurious\]](https://osu.ppy.sh/beatmapsets/2527057#taiko/5582884)
+- Hidden
+  1. [seatrus - Raindrop (Grape\_Tea) \[Inner Oni\]](https://osu.ppy.sh/beatmapsets/2527055#taiko/5582877)
+  2. Marmalade butcher - Open Scar Unending (Eyenine) \[Torrington Wrestling Club\] (link pending)
+- Hard Rock
+  1. [steelplus - Skywired Beatscape (Hivie) \[Sanctuary\]](https://osu.ppy.sh/beatmapsets/2527061#taiko/5582903)
+  2. [orangentle / Yu\_Asahina - OEFHEBEN (Alwaysyukaz) \[Almighty Power (TWC Ver.)\]](https://osu.ppy.sh/beatmapsets/2428701#taiko/5582896)
+- Double Time
+  1. Yunomi - Game Over (feat. TORIENA) (komasy) \[Game Start (TWC Edit)\] (link pending)
+  2. [A-One - Side by Side (OnosakiHito) \[Inner Oni (TWC Ver.)\]](https://osu.ppy.sh/beatmapsets/2527072#taiko/5582922)
+- Free Mod
+  1. [Zekk - Quantum L3ap (Maimaing) \[Inn3r Oni\]](https://osu.ppy.sh/beatmapsets/2527065#taiko/5582908)
+  2. [Memme - Erebus (Ectomic) \[Inner Oni (TWC2026)\]](https://osu.ppy.sh/beatmapsets/2527070#taiko/5582920)
+- Tiebreaker
+  1. **[Cansol - Out of Place (Nurend) \[Wandering Wolf\]](https://osu.ppy.sh/beatmapsets/2527074#taiko/5582924)**
 
 ### Group stage
 


### PR DESCRIPTION
Adds Group stage results/VODs. Adds Round of 16 schedules and mappools. Updates links and staff listing.